### PR TITLE
Remove the speed limit from grinding

### DIFF
--- a/sq_skate.qc
+++ b/sq_skate.qc
@@ -727,14 +727,6 @@ local vector 	new_vel;
 
 		if (onrail() && (self.trick == TRICK_GRIND))
 		{
-		//check if player is slower than expected-->grinding up-->fall!hahaha
-			if (self.grind_start_time + 0.5 < time && vlen(self.velocity) < 150)
-			{
-				sprint(self,"You don't have enough speed!\n");
-				skate_fall();
-				return;
-			}
-		//end check
 
 			new_vel = 280 * v_forward;		//grind to the right (with frames)
 			self.velocity_z = -280;			//grind down somewhere


### PR DESCRIPTION
If you move too slow on a grind, you will fail it. The problem is that this limit is very arbitrary, I could not find a value change which made sense. Lowering it barely makes a difference. The downside of this is removing the usefulness of momentum shifted multi grinds, but this is a relatively unknown tech. It isn't even documented in the wiki, and is useless due to the removal of stamina. I feel that if I'm going to be attempting a larger change to grinding mechanics, this NEEDS to be removed first.