### PR TITLE
Dynamic grind speed + faster grind speed

### DIFF
--- a/sq_skate.qc
+++ b/sq_skate.qc
@@ -624,7 +624,7 @@ local float	fell;
 				sprint(self, " to Backside Boardslide");	//......
 			}
 		}
-		sprint(self, " !\n");
+		sprint(self, "!\n");
 
 		if (trick_points > 1)
 		{
@@ -727,16 +727,17 @@ local vector 	new_vel;
 
 		if (onrail() && (self.trick == TRICK_GRIND))
 		{
-		//check if player is slower than expected-->grinding up-->fall!hahaha
-			if (self.grind_start_time + 0.5 < time && vlen(self.velocity) < 150)
+		//check if player is slower than expected
+			if (vlen(self.velocity) < 320)
 			{
-				sprint(self,"You don't have enough speed !\n");
-				skate_fall();
-				return;
+				new_vel = 320 * v_forward;		//grind to the right (with frames)
+			}
+			if (vlen(self.velocity) > 320)		// if player is faster than expected, they'll use their current speed
+			{
+				vlen(new_vel) = vlen(self.velocity);		//grind to the right (with frames)
 			}
 		//end check
 
-			new_vel = 280 * v_forward;		//grind to the right (with frames)
 			self.velocity_z = -280;			//grind down somewhere
 			self.grind_stop_time = time;		//update stop time. when in air, it won't be set
 			if (self.super_sound < time)		//play grinding sound
@@ -748,7 +749,7 @@ local vector 	new_vel;
 
 		if (!onrail() && (self.trick == TRICK_GRIND))
 		{
-			sprint(self,"You skipped a grind !\n");
+			sprint(self,"You skipped a grind!\n");
 			self.jump_flag = -1000;
 			skate_fall();
 			return;


### PR DESCRIPTION
Hacky way of doing this, but it theoretically works. If the player is going too slow to benefit from a dynamic grind speed, they will receive a constant speed. Players going faster than 320 units will continue to go the speed they are currently going, slowly losing speed over time. Along with this, grinding is now slightly faster overall. Speed has been increased from 280 > 320. Done quite a bit of testing so it shouldn't break anything, maybe!