### PR TITLE
V1.2: Rise and grind

### DIFF
--- a/sq_skate.qc
+++ b/sq_skate.qc
@@ -726,9 +726,17 @@ local vector 	new_vel;
 		}
 
 		if (onrail() && (self.trick == TRICK_GRIND))
-		{
-
-			new_vel = 280 * v_forward;		//grind to the right (with frames)
+        {
+        //check if player is slower than expected
+            if (vlen(self.velocity) < 320)
+            {
+                new_vel = 320 * v_forward;        //grind to the right (with frames)
+            }
+            if (vlen(self.velocity) > 320)
+            {
+                vlen(new_vel) = vlen(self.velocity);        //grind to the right (with frames)
+            }
+        //end check
 			self.velocity_z = -280;			//grind down somewhere
 			self.grind_stop_time = time;		//update stop time. when in air, it won't be set
 			if (self.super_sound < time)		//play grinding sound

--- a/sq_skate.qc
+++ b/sq_skate.qc
@@ -731,13 +731,14 @@ local vector 	new_vel;
             if (vlen(self.velocity) < 320)
             {
                 new_vel = 320 * v_forward;        //grind to the right (with frames)
+		self.velocity_z = -120;		//If skating forward or up hill, activate feather falling
             }
             if (vlen(self.velocity) > 320)
             {
                 vlen(new_vel) = vlen(self.velocity);        //grind to the right (with frames)
+		self.velocity_z = -280;			//If skating downhill, activate fox shoes
             }
         //end check
-			self.velocity_z = -120;			//grind down somewhere
 			self.grind_stop_time = time;		//update stop time. when in air, it won't be set
 			if (self.super_sound < time)		//play grinding sound
 			{						//use super_sound for right timing

--- a/sq_skate.qc
+++ b/sq_skate.qc
@@ -728,7 +728,7 @@ local vector 	new_vel;
 		if (onrail() && (self.trick == TRICK_GRIND))
         {
         //check if player is slower than expected
-            if (vlen(self.velocity) < 320)
+            if (vlen(self.velocity) <= 320)
             {
                 new_vel = 320 * v_forward;        //grind to the right (with frames)
 		self.velocity_z = -120;		//If skating forward or up hill, activate feather falling

--- a/sq_skate.qc
+++ b/sq_skate.qc
@@ -624,7 +624,7 @@ local float	fell;
 				sprint(self, " to Backside Boardslide");	//......
 			}
 		}
-		sprint(self, " !\n");
+		sprint(self, "!\n");
 
 		if (trick_points > 1)
 		{
@@ -730,7 +730,7 @@ local vector 	new_vel;
 		//check if player is slower than expected-->grinding up-->fall!hahaha
 			if (self.grind_start_time + 0.5 < time && vlen(self.velocity) < 150)
 			{
-				sprint(self,"You don't have enough speed !\n");
+				sprint(self,"You don't have enough speed!\n");
 				skate_fall();
 				return;
 			}
@@ -748,7 +748,7 @@ local vector 	new_vel;
 
 		if (!onrail() && (self.trick == TRICK_GRIND))
 		{
-			sprint(self,"You skipped a grind !\n");
+			sprint(self,"You skipped a grind!\n");
 			self.jump_flag = -1000;
 			skate_fall();
 			return;

--- a/sq_skate.qc
+++ b/sq_skate.qc
@@ -737,7 +737,7 @@ local vector 	new_vel;
                 vlen(new_vel) = vlen(self.velocity);        //grind to the right (with frames)
             }
         //end check
-			self.velocity_z = -280;			//grind down somewhere
+			self.velocity_z = -120;			//grind down somewhere
 			self.grind_stop_time = time;		//update stop time. when in air, it won't be set
 			if (self.super_sound < time)		//play grinding sound
 			{						//use super_sound for right timing

--- a/sq_skate.qc
+++ b/sq_skate.qc
@@ -727,14 +727,6 @@ local vector 	new_vel;
 
 		if (onrail() && (self.trick == TRICK_GRIND))
 		{
-		//check if player is slower than expected-->grinding up-->fall!hahaha
-			if (self.grind_start_time + 0.5 < time && vlen(self.velocity) < 150)
-			{
-				sprint(self,"You don't have enough speed!\n");
-				skate_fall();
-				return;
-			}
-		//end check
 
 			new_vel = 280 * v_forward;		//grind to the right (with frames)
 			self.velocity_z = -280;			//grind down somewhere


### PR DESCRIPTION
This update aims to make a lot of changes to grinding on rails. Like, a lot. Below are all changes.

Old  | New
------------- | -------------
Grind speed is 280, no matter what.  | ***Default*** grind speed is 320, can increase based on momentum.

Made grinding faster by a tad, felt better. Along with this, the ***default*** tag is now used to describe the speed a player goes by default. Default is defined by any speed under 320 (approaching a rail while under 320 will automatically set your speed to 320). For speeds over 320, the player's momentum will be carried unto the grind. This speed slowly depletes over time when on a rail, returning back to the default. If you jump off of a rail at any point, you keep your momentum.

Old  | New
------------- | -------------
Exclamation marks have a space before them  | Exclamation marks do not have a space before them

I have no idea why squirt did this, but now there are no spaces before the exclamation mark proclaiming you've done a trick. Left it in his comments, though. Those are his.


Old  | New
------------- | -------------
If going slower than expected, you'll fail a grind. | You can't fail a grind due to a lack of speed.

There's merit to keeping this mechanic in Kickflip Quake, but not KFQuake. Due to the removal of stamina, tech like Momentum Shifted Multi Grinds are not really important, meaning that you can just spam jump to reset your momentum and consequently the timer. There was no satisfying way to keep this in, either by increasing or decreasing the speed at which a grind fails. So I'm removing it, I reckon it's the best course of action.

Old  | New
------------- | -------------
When on a rail, fall speed is set to -280 regardless of direction. | When going ***up a rail or going straight***, fall speed is set to -120. When going ***down a rail or going faster than the default speed***, fall speed is set to -280.

Very hard to explain this one, but bear with me here. With the default speed, it is incredibly annoying to fall as fast as you do. It legitimately feels like you have concrete shoes on despite going a very average speed, and makes tricks requiring falling off of a rail annoying and oddly specific. Reducing the speed at which you fall, however, means that you do not gain much speed when going down a rail. The solution to this is actually pretty simple, change your fall speed depending on whether or not you're going up or down. When going down, you fall at the regular Kickflip Quake speed and gain a good amount of speed. When going up a rail or going straight, "feather falling" is activated, and you'll fall at more or less the same speed as you would just jumping. Not a perfect solution, fast falling activating when going faster than normal is a bug. I like it though. Feels significantly more natural, and in general with high speeds on rails, you're going to jump off to unlock air strafing. Will update this pull request if I think of more things to update related to grinding by tomorrow, but this can be mostly considered the final draft.

Free Melee, still. :)