### PR TITLE
Having quad will remove the air strafe lock

### DIFF
--- a/sq_skate.qc
+++ b/sq_skate.qc
@@ -757,7 +757,7 @@ local vector 	new_vel;
 		//	self.busting = TRUE;
 		//}
 	}
-	else if (vlen(self.jump_vel) != 0)
+	else if (vlen(self.jump_vel) != 0 && self.super_time == 0)
 	{		//realistic jumping movement (player can't change direction)
 		self.velocity_x = self.jump_vel_x;				//don't change up or down movement
 		self.velocity_y = self.jump_vel_y;				//


### PR DESCRIPTION
If you have quad damage, you can air strafe without needing to do any additional advanced tech. You can use quad found around maps to air strafe without worry, or impulse 255 to remove the air strafe lock at any time. That's up to you! I plan to add more perks for powerups as well, but for now this is what I've done.